### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# revision24601.github.io
+
+Personal portfolio website for Nischay Mohan.
+
+## Cursor Cloud specific instructions
+
+### What this repo is
+- Primary product: a **static portfolio website** (deployed via GitHub Pages — `.nojekyll` disables Jekyll). The real pages are the root-level HTML files: `index.html` (home), `projects.html`, `about.html`, plus assets in `static/`.
+- Secondary: a small **Flask dev server** (`app.py`, and a near-duplicate `app/routes.py`) that renders pages from `templates/` via Jinja2.
+- `parallax-master/` is a vendored third-party library (Parallax.js), not a product built here; its pre-built output already exists in `parallax-master/deploy/`.
+
+### Running the site (dev)
+- Static site (matches how GitHub Pages serves it), from the repo root: `python3 -m http.server 8000` then open `http://127.0.0.1:8000/index.html`. Uses only the Python stdlib.
+- Flask server: `python3 app.py` serves on `0.0.0.0:5000` (debug on). `app/routes.py` binds Flask defaults (`127.0.0.1:5000`).
+
+### Non-obvious caveats
+- **The Flask app is broken on `master`.** `app.py` calls `render_template('index.html')`, but on `master` the `templates/` folder only contains `base.html`, so requests return HTTP 500 (`TemplateNotFound`). The complete Jinja templates (`templates/index.html`, `projects.html`, `about.html`) live on the **`flask` branch** — check out that branch to develop/run the Flask serving path. On `master`, use the static server above to run the product.
+- There is **no `requirements.txt`/`pyproject.toml`**; Flask is the only Python dependency and is installed via pip (see update script).
+- There are **no automated tests and no lint config** in this repo.
+- The floating chatbot widget (`static/js/chatbot.js`) calls the OpenAI API directly from the browser and requires a valid key; it is optional and non-blocking for viewing the site. Note the file currently contains a hard-coded API key committed to the repo.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up and documents the development environment for this repository (a static GitHub Pages portfolio site plus a Flask dev server).

- Adds `AGENTS.md` with `## Cursor Cloud specific instructions` covering how to run the site, plus non-obvious caveats.
- Registers an update script (`pip install --break-system-packages flask`) to refresh the single Python dependency on VM startup. There is no `requirements.txt` in the repo.

## Environment findings
- **Product:** static portfolio website (`index.html`, `projects.html`, `about.html`, `static/`) served by GitHub Pages. Run locally with `python3 -m http.server 8000` from the repo root.
- **Flask dev server** (`app.py`) exists but is **broken on `master`**: it renders `templates/index.html`, but `master`'s `templates/` only contains `base.html`, so it returns HTTP 500 `TemplateNotFound`. The complete templates live on the `flask` branch. This is a pre-existing code issue — not modified here.
- No automated tests or lint config exist.

## Verification
Served the static site and verified pages return HTTP 200 (`/index.html`, `/projects.html`, `/static/css/style.css`) with the correct title, then navigated Home → Projects in Chrome.

[portfolio_site_navigation_demo.mp4](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fportfolio_site_navigation_demo.mp4)

[Homepage hero](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_hero.webp)
[Projects page](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_page.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

