### PR TITLE
Design foundation: typography-first digital garden (light/dark, garden signals, hand-drawn diagrams)

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,23 +3,94 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>About - Nischay Mohan</title>
+    <title>About this garden &mdash; Nischay Mohan</title>
+    <meta name="description" content="Why a garden and not a portfolio, and how to read the seedling / stub / evergreen labels.">
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("theme");
+          if (!t) t = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="stylesheet" href="static/css/style.css">
 </head>
 <body>
-    <div class="test-banner">Testing</div>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="projects.html">Projects</a>
-    </nav>
+    <a class="skip-link" href="#main">Skip to content</a>
 
-    <main>
-        <h1>About Me</h1>
-        <p>This is where you can write about yourself.</p>
+    <header class="site-header">
+        <div class="wrap">
+            <a class="brand" href="index.html"><span class="leaf">&#127793;</span> Nischay Mohan</a>
+            <nav class="nav" aria-label="Primary">
+                <a href="index.html">Home</a>
+                <a href="projects.html">Notes</a>
+                <a href="about.html" aria-current="page">About</a>
+                <button class="theme-toggle" data-theme-toggle type="button"
+                        aria-label="Switch to dark theme" aria-pressed="false" title="Toggle theme">
+                    <span class="icon-moon" aria-hidden="true">&#9789;</span>
+                    <span class="icon-sun" aria-hidden="true">&#9728;</span>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main">
+        <div class="wrap">
+            <article class="essay">
+                <h1>About this garden</h1>
+                <p class="meta">
+                    <span class="badge badge--evergreen">Colophon</span>
+                    <span>Last tended <time datetime="2026-07-05">5 Jul 2026</time></span>
+                </p>
+
+                <p>This is a <strong>digital garden</strong>, not a portfolio. A portfolio is finished and
+                sells you something; a garden is tended, changes over time, and is happy to show
+                half-grown ideas. I write here to think in public about how financial systems actually
+                work.</p>
+
+                <h2>What grows here</h2>
+                <p>Three threads, all kept conceptual and general:</p>
+                <ul>
+                    <li><strong>Payments under the hood</strong> &mdash; the mechanics of moving money.</li>
+                    <li><strong>The geopolitics of money</strong> &mdash; who controls the rails, and why
+                    that's power.</li>
+                    <li><strong>AI as leverage</strong> &mdash; where machine intelligence really changes
+                    the economics of finance.</li>
+                </ul>
+
+                <h2>How to read the labels</h2>
+                <ul>
+                    <li><span class="badge badge--stub">Stub</span> a placeholder &mdash; a title and a
+                    sentence, waiting to be written.</li>
+                    <li><span class="badge badge--seedling">&#127793; Seedling</span> young and growing &mdash;
+                    real but unfinished, likely to change.</li>
+                    <li><span class="badge badge--evergreen">Evergreen</span> tended enough that I trust it,
+                    though nothing here is ever truly "done".</li>
+                </ul>
+
+                <h2>How it's built</h2>
+                <p>Deliberately boring: hand-written HTML and CSS, system fonts only, a sprinkle of
+                JavaScript for the light/dark toggle, and inline SVG for the hand-drawn diagrams. Fast to
+                load, easy to tend.</p>
+
+                <aside class="backlinks">
+                    <h2>Related</h2>
+                    <ul>
+                        <li><a href="how-money-moves.html">How money moves</a></li>
+                        <li><a href="index.html">Back to the front page</a></li>
+                    </ul>
+                </aside>
+            </article>
+        </div>
     </main>
 
-    <footer>
-        <p>© 2025 Nischay Mohan | <a href="mailto:nischaym@amazon.com">Contact Me</a></p>
+    <footer class="site-footer">
+        <div class="wrap">
+            <p>Tended by Nischay Mohan &middot; a learn-in-public digital garden.</p>
+        </div>
     </footer>
+
+    <script src="static/js/theme.js"></script>
 </body>
 </html>

--- a/how-money-moves.html
+++ b/how-money-moves.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How money moves &mdash; Nischay Mohan</title>
+    <meta name="description" content="Authorization vs. clearing vs. settlement, in plain language.">
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("theme");
+          if (!t) t = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
+    <link rel="stylesheet" href="static/css/style.css">
+</head>
+<body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+        <div class="wrap">
+            <a class="brand" href="index.html"><span class="leaf">&#127793;</span> Nischay Mohan</a>
+            <nav class="nav" aria-label="Primary">
+                <a href="index.html">Home</a>
+                <a href="projects.html">Notes</a>
+                <a href="about.html">About</a>
+                <button class="theme-toggle" data-theme-toggle type="button"
+                        aria-label="Switch to dark theme" aria-pressed="false" title="Toggle theme">
+                    <span class="icon-moon" aria-hidden="true">&#9789;</span>
+                    <span class="icon-sun" aria-hidden="true">&#9728;</span>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main">
+        <div class="wrap">
+            <article class="essay">
+                <h1>How money moves</h1>
+                <p class="meta">
+                    <span class="badge badge--seedling">&#127793; Seedling</span>
+                    <span>Created <time datetime="2026-06-28">28 Jun 2026</time></span>
+                    <span>Last tended <time datetime="2026-07-05">5 Jul 2026</time></span>
+                </p>
+
+                <p>Most people say "I paid" as if it were one instant event. Under the hood it's at least
+                three: <strong>authorization</strong>, <strong>clearing</strong>, and
+                <strong>settlement</strong>. They run on different clocks, and almost everything
+                interesting about payments &mdash; fraud, disputes, float, fees &mdash; lives in the gaps
+                between them.</p>
+
+                <p>Quick definitions, since the jargon does real work here:</p>
+                <ul>
+                    <li><strong>Authorization</strong> &mdash; a fast "yes/no": does this account have the
+                    funds and does it look legitimate? Money doesn't move yet; it's just earmarked.</li>
+                    <li><strong>Clearing</strong> &mdash; the parties reconcile who owes whom, netting many
+                    transactions against each other.</li>
+                    <li><strong>Settlement</strong> &mdash; the actual transfer of value between banks, so
+                    the merchant is genuinely paid.</li>
+                </ul>
+
+                <figure class="diagram" role="group" aria-labelledby="dia2-cap">
+                    <svg viewBox="0 0 340 320" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                        <defs>
+                            <filter id="hd2" x="-20%" y="-20%" width="140%" height="140%">
+                                <feTurbulence type="fractalNoise" baseFrequency="0.014" numOctaves="2" seed="9" result="n"/>
+                                <feDisplacementMap in="SourceGraphic" in2="n" scale="3" xChannelSelector="R" yChannelSelector="G"/>
+                            </filter>
+                            <marker id="arrow2" viewBox="0 0 10 10" refX="8" refY="5"
+                                    markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                                <path class="arrowhead" d="M0,0 L10,5 L0,10 z"/>
+                            </marker>
+                        </defs>
+                        <g filter="url(#hd2)">
+                            <line class="flow" x1="170" y1="66"  x2="170" y2="118" marker-end="url(#arrow2)"/>
+                            <line class="flow" x1="170" y1="172" x2="170" y2="224" marker-end="url(#arrow2)"
+                                  stroke-dasharray="6 6"/>
+                            <rect class="node" x="70" y="12"  width="200" height="54" rx="10"/>
+                            <rect class="node" x="70" y="118" width="200" height="54" rx="10"/>
+                            <rect class="node" x="70" y="224" width="200" height="54" rx="10"/>
+                        </g>
+                        <text class="label" x="170" y="36"  text-anchor="middle">Tap / swipe</text>
+                        <text class="sub"   x="170" y="54"  text-anchor="middle">the purchase</text>
+                        <text class="label" x="170" y="142" text-anchor="middle">Authorized</text>
+                        <text class="sub"   x="170" y="160" text-anchor="middle">funds held, ~2 seconds</text>
+                        <text class="label" x="170" y="248" text-anchor="middle">Settled</text>
+                        <text class="sub"   x="170" y="266" text-anchor="middle">money moves, T+1 to T+3</text>
+                        <text class="flow-label" x="178" y="98"  text-anchor="start">instant</text>
+                        <text class="flow-label" x="178" y="204" text-anchor="start">hours&ndash;days</text>
+                    </svg>
+                    <figcaption id="dia2-cap">Two clocks: the "yes" is instant; the money is slow.</figcaption>
+                </figure>
+
+                <blockquote>The float &mdash; that quiet window between "authorized" and "settled" &mdash;
+                is where a surprising amount of the payments business, and its risk, actually sits.</blockquote>
+
+                <p>This is a seedling: I'll grow it with a worked example of a single $10 coffee moving
+                through the chain, and prune the hand-waving as I go.</p>
+
+                <aside class="backlinks">
+                    <h2>Related</h2>
+                    <ul>
+                        <li><a href="projects.html">Who controls the rails?</a> &mdash; once you know how
+                        money moves, the next question is who can stop it.</li>
+                        <li><a href="index.html">The garden, front page</a></li>
+                    </ul>
+                </aside>
+            </article>
+        </div>
+    </main>
+
+    <footer class="site-footer">
+        <div class="wrap">
+            <p>Tended by Nischay Mohan &middot; a learn-in-public digital garden.</p>
+        </div>
+    </footer>
+
+    <script src="static/js/theme.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,93 +3,177 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Nischay Mohan - Software Engineer</title>
+    <title>Nischay Mohan — a digital garden on money, rails & AI</title>
+    <meta name="description" content="A working notebook on how money actually moves: the plumbing of payments, the geopolitics of the rails, and AI as leverage over financial systems.">
+    <!-- Set the theme before paint to avoid a flash of the wrong colours. -->
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("theme");
+          if (!t) t = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="stylesheet" href="static/css/style.css">
 </head>
 <body>
+    <a class="skip-link" href="#main">Skip to content</a>
 
-    <!-- Testing Banner -->
-    <div class="test-banner">Testing</div>
+    <header class="site-header">
+        <div class="wrap">
+            <a class="brand" href="index.html"><span class="leaf">&#127793;</span> Nischay Mohan</a>
+            <nav class="nav" aria-label="Primary">
+                <a href="index.html" aria-current="page">Home</a>
+                <a href="projects.html">Notes</a>
+                <a href="about.html">About</a>
+                <button class="theme-toggle" data-theme-toggle type="button"
+                        aria-label="Switch to dark theme" aria-pressed="false" title="Toggle theme">
+                    <span class="icon-moon" aria-hidden="true">&#9789;</span>
+                    <span class="icon-sun" aria-hidden="true">&#9728;</span>
+                </button>
+            </nav>
+        </div>
+    </header>
 
-    <!-- Navigation Bar -->
-    <nav>
-        <a href="index.html">🏠 Home</a>
-        <a href="projects.html">📂 Projects</a>
-    </nav>    
+    <main id="main">
+        <div class="wrap">
+            <section class="intro">
+                <p class="kicker">Digital garden &middot; tended in public</p>
+                <h1>How money moves &mdash; and who moves it.</h1>
+                <p class="lede">A working notebook at the intersection of three things: the plumbing of
+                payment systems, the geopolitics of the rails that carry money, and AI as leverage over
+                financial systems.</p>
 
-    <main>
-        <header class="hero">
-            <div class="hero-content">
-                <h1 class="fade-in">Hi, I'm <span class="highlight">Nischay Mohan</span></h1>
-                <h2 class="fade-in-delay">Software Development Manager | AWS | Event-Driven Architect</h2>
-                <p class="fade-in-late">Passionate about building scalable cloud solutions and empowering engineering teams.</p>
-                <div class="buttons">
-                    <a href="https://linkedin.com/in/nischaymohan" class="btn">LinkedIn</a>
-                    <a href="https://github.com/Revision24601" class="btn">GitHub</a>
-                    <a href="static/resume.pdf" class="btn btn-alt">View Resume</a>
-                </div>
-            </div>
-        </header>
+                <p>This isn't a r&eacute;sum&eacute;. It's a <strong>commonplace book</strong> &mdash; part
+                long-form essay, part short atomic note &mdash; that I tend over time. Some pieces are
+                finished; many are seedlings; a few are just stubs. I think in public here, so expect ideas
+                to grow, get pruned, and cross-link as I learn.</p>
 
-        <section class="about">
-            <h2>About Me</h2>
-            <p>I am a Software Development Manager at AWS, specializing in event-driven architectures, cloud computing, and AI-driven solutions. My expertise lies in leading engineering teams to build scalable, high-performance applications.</p>
-        </section>
+                <ul class="threads">
+                    <li><strong>Payments under the hood.</strong> What actually happens between tapping a
+                    card and money landing in a merchant's account.</li>
+                    <li><strong>The geopolitics of money.</strong> Who owns the rails, who can switch them
+                    off, and why that is quietly one of the most important forms of power.</li>
+                    <li><strong>AI as leverage.</strong> Where machine intelligence genuinely changes the
+                    economics of moving, checking, and governing money &mdash; and where it's just hype.</li>
+                </ul>
+            </section>
 
-        <section class="skills">
-            <h2>My Tech Stack</h2>
-            <div class="skills-grid">
-                <div class="skill">☁ Cloud Computing (AWS, Azure)</div>
-                <div class="skill">⚡ Event-Driven Architectures</div>
-                <div class="skill">🤖 AI & Generative AI</div>
-                <div class="skill">🚀 Serverless Development</div>
-                <div class="skill">🐍 Python, Java, C++</div>
-                <div class="skill">🎯 Software Engineering Leadership</div>
-            </div>
-        </section>
+            <hr>
 
-        <section class="projects">
-            <h2>Featured Projects</h2>
-            <div class="project-list">
-                <div class="project">
-                    <img src="static/images/munich.JPG" alt="Project Image">
-                    <h3>AI-Powered Cloud Monitoring</h3>
-                    <p>Built an intelligent cloud monitoring system using AWS Lambda, DynamoDB, and AI anomaly detection.</p>
-                    <a href="projects.html" class="btn">View Details</a>
-                </div>
-                <div class="project">
-                    <img src="static/images/leshark.png" alt="Project Image">
-                    <h3>Real-Time EventBridge Analytics</h3>
-                    <p>Developed a real-time analytics dashboard for AWS EventBridge using React & Flask.</p>
-                    <a href="projects.html" class="btn">View Details</a>
-                </div>
-            </div>
-        </section>
+            <!-- Signature element: a hand-drawn-feeling flow diagram. It's inline SVG
+                 painted with currentColor, so it reads cleanly in light and dark. -->
+            <figure class="diagram" role="group" aria-labelledby="dia1-cap">
+                <svg viewBox="0 0 340 540" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                    <defs>
+                        <filter id="hd1" x="-20%" y="-20%" width="140%" height="140%">
+                            <feTurbulence type="fractalNoise" baseFrequency="0.014" numOctaves="2" seed="5" result="n"/>
+                            <feDisplacementMap in="SourceGraphic" in2="n" scale="3.2" xChannelSelector="R" yChannelSelector="G"/>
+                        </filter>
+                        <marker id="arrow1" viewBox="0 0 10 10" refX="8" refY="5"
+                                markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+                            <path class="arrowhead" d="M0,0 L10,5 L0,10 z"/>
+                        </marker>
+                    </defs>
+
+                    <g filter="url(#hd1)">
+                        <!-- Flow: authorization hops down the chain -->
+                        <line class="flow" x1="124" y1="60"  x2="124" y2="112" marker-end="url(#arrow1)"/>
+                        <line class="flow" x1="124" y1="166" x2="124" y2="218" marker-end="url(#arrow1)"/>
+                        <line class="flow" x1="124" y1="272" x2="124" y2="324" marker-end="url(#arrow1)"/>
+                        <line class="flow" x1="124" y1="378" x2="124" y2="430" marker-end="url(#arrow1)"/>
+                        <!-- Return path: the money actually settles back up -->
+                        <path class="flow" d="M224,457 C296,457 305,448 305,420 L305,70 C305,42 296,33 224,33"
+                              marker-end="url(#arrow1)"/>
+
+                        <rect class="node" x="24" y="6"   width="200" height="54" rx="10"/>
+                        <rect class="node" x="24" y="112" width="200" height="54" rx="10"/>
+                        <rect class="node" x="24" y="218" width="200" height="54" rx="10"/>
+                        <rect class="node" x="24" y="324" width="200" height="54" rx="10"/>
+                        <rect class="node" x="24" y="430" width="200" height="54" rx="10"/>
+                    </g>
+
+                    <!-- Text stays un-displaced so it's crisp -->
+                    <text class="label" x="124" y="30"  text-anchor="middle">You</text>
+                    <text class="sub"   x="124" y="48"  text-anchor="middle">the cardholder</text>
+                    <text class="label" x="124" y="136" text-anchor="middle">Merchant</text>
+                    <text class="sub"   x="124" y="154" text-anchor="middle">the shop</text>
+                    <text class="label" x="124" y="242" text-anchor="middle">Acquirer</text>
+                    <text class="sub"   x="124" y="260" text-anchor="middle">the shop's bank</text>
+                    <text class="label" x="124" y="348" text-anchor="middle">Card network</text>
+                    <text class="sub"   x="124" y="366" text-anchor="middle">the rails</text>
+                    <text class="label" x="124" y="454" text-anchor="middle">Issuer</text>
+                    <text class="sub"   x="124" y="472" text-anchor="middle">your bank</text>
+
+                    <text class="flow-label" x="132" y="92" text-anchor="start">1 &middot; authorizes</text>
+                    <text class="flow-label" x="318" y="250" text-anchor="middle"
+                          transform="rotate(-90 318 250)">2 &middot; settles</text>
+                </svg>
+                <figcaption id="dia1-cap">A card payment, end to end. The <em>authorization</em> hops
+                down the chain in a second or two; the actual money <em>settles</em> back up over hours or
+                days. Two different clocks &mdash; that gap is where a lot of the interesting stuff lives.</figcaption>
+            </figure>
+
+            <hr>
+
+            <section>
+                <h2>In the garden</h2>
+                <p>A few things currently growing. Dates show when a note was planted and last tended.</p>
+
+                <ul class="card-grid">
+                    <li class="card">
+                        <h3><a href="how-money-moves.html">How money moves</a>
+                            <span class="badge badge--seedling">&#127793; Seedling</span></h3>
+                        <p>Authorization vs. clearing vs. settlement, in plain language &mdash; the three
+                        steps most people compress into the word "payment".</p>
+                        <p class="meta">
+                            <span>Created <time datetime="2026-06-28">28 Jun 2026</time></span>
+                            <span>Tended <time datetime="2026-07-05">5 Jul 2026</time></span>
+                        </p>
+                    </li>
+                    <li class="card">
+                        <h3><a href="projects.html">Who controls the rails?</a>
+                            <span class="badge badge--stub">Stub</span></h3>
+                        <p>A map of the systems that clear cross-border money, and what "control" actually
+                        means when you can be removed from a network.</p>
+                        <p class="meta">
+                            <span>Created <time datetime="2026-07-02">2 Jul 2026</time></span>
+                            <span>Tended <time datetime="2026-07-02">2 Jul 2026</time></span>
+                        </p>
+                    </li>
+                    <li class="card">
+                        <h3><a href="projects.html">AI as leverage over money</a>
+                            <span class="badge badge--stub">Stub</span></h3>
+                        <p>Where models genuinely change the economics of moving and checking money &mdash;
+                        and where "AI" is doing rhetorical rather than real work.</p>
+                        <p class="meta">
+                            <span>Created <time datetime="2026-07-03">3 Jul 2026</time></span>
+                            <span>Tended <time datetime="2026-07-03">3 Jul 2026</time></span>
+                        </p>
+                    </li>
+                    <li class="card">
+                        <h3><a href="about.html">About this garden</a>
+                            <span class="badge badge--evergreen">Colophon</span></h3>
+                        <p>Why a garden and not a portfolio, how it's built, and how to read the seedling /
+                        stub / evergreen labels.</p>
+                        <p class="meta">
+                            <span>Created <time datetime="2026-06-28">28 Jun 2026</time></span>
+                            <span>Tended <time datetime="2026-07-05">5 Jul 2026</time></span>
+                        </p>
+                    </li>
+                </ul>
+            </section>
+        </div>
     </main>
 
-    <!-- Floating Chatbot Icon -->
-    <div id="chat-icon">
-        💬
-    </div>
-
-    <!-- Chatbot Pop-up -->
-    <div id="chat-container">
-        <div id="chat-header">
-            <span>🤖 Chat with AI</span>
-            <button id="close-chat">✖</button>
+    <footer class="site-footer">
+        <div class="wrap">
+            <p>Tended by Nischay Mohan &middot; a learn-in-public digital garden.
+            <br>Everything here is conceptual and general &mdash; opinions are my own.</p>
         </div>
-        <div id="chat-box"></div>
-        <input type="text" id="user-input" placeholder="Ask me anything...">
-        <button id="send-btn">Send</button>
-    </div>
-
-    <!-- Footer -->
-    <footer>
-        <p>© 2025 Nischay Mohan | <a href="mailto:nischaym@amazon.com">Contact Me</a></p>
     </footer>
 
-    <!-- Chatbot JavaScript -->
-    <script src="static/js/chatbot.js"></script>
-
+    <script src="static/js/theme.js"></script>
 </body>
 </html>

--- a/projects.html
+++ b/projects.html
@@ -3,24 +3,83 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Projects - Nischay Mohan</title>
+    <title>Notes &mdash; Nischay Mohan</title>
+    <meta name="description" content="Atomic notes and essays, growing over time.">
+    <script>
+      (function () {
+        try {
+          var t = localStorage.getItem("theme");
+          if (!t) t = matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+          document.documentElement.setAttribute("data-theme", t);
+        } catch (e) {}
+      })();
+    </script>
     <link rel="stylesheet" href="static/css/style.css">
 </head>
 <body>
-    <div class="test-banner">Testing</div>
-    <nav>
-        <a href="index.html">Home</a>
-        <a href="projects.html">Projects</a>
-    </nav>
+    <a class="skip-link" href="#main">Skip to content</a>
 
-    <main>
-        <h1>le projects</h1>
-        <img src="static/images/munich.JPG" width="250" height="250">
-        <a href="#">Link</a>
+    <header class="site-header">
+        <div class="wrap">
+            <a class="brand" href="index.html"><span class="leaf">&#127793;</span> Nischay Mohan</a>
+            <nav class="nav" aria-label="Primary">
+                <a href="index.html">Home</a>
+                <a href="projects.html" aria-current="page">Notes</a>
+                <a href="about.html">About</a>
+                <button class="theme-toggle" data-theme-toggle type="button"
+                        aria-label="Switch to dark theme" aria-pressed="false" title="Toggle theme">
+                    <span class="icon-moon" aria-hidden="true">&#9789;</span>
+                    <span class="icon-sun" aria-hidden="true">&#9728;</span>
+                </button>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main">
+        <div class="wrap">
+            <section>
+                <p class="kicker">The notes</p>
+                <h1>Everything currently growing</h1>
+                <p>Atomic notes and longer essays, newest tending first. Stubs are on purpose &mdash; a
+                title I've committed to filling in later.</p>
+
+                <ul class="card-grid">
+                    <li class="card">
+                        <h3><a href="how-money-moves.html">How money moves</a>
+                            <span class="badge badge--seedling">&#127793; Seedling</span></h3>
+                        <p>Authorization vs. clearing vs. settlement, in plain language.</p>
+                        <p class="meta">
+                            <span>Tended <time datetime="2026-07-05">5 Jul 2026</time></span>
+                        </p>
+                    </li>
+                    <li class="card">
+                        <h3>Who controls the rails?
+                            <span class="badge badge--stub">Stub</span></h3>
+                        <p>A map of the systems that clear cross-border money, and what "control" means
+                        when you can be removed from a network.</p>
+                        <p class="meta">
+                            <span>Tended <time datetime="2026-07-02">2 Jul 2026</time></span>
+                        </p>
+                    </li>
+                    <li class="card">
+                        <h3>AI as leverage over money
+                            <span class="badge badge--stub">Stub</span></h3>
+                        <p>Where models genuinely change the economics of moving and checking money.</p>
+                        <p class="meta">
+                            <span>Tended <time datetime="2026-07-03">3 Jul 2026</time></span>
+                        </p>
+                    </li>
+                </ul>
+            </section>
+        </div>
     </main>
 
-    <footer>
-        <p>© 2025 Nischay Mohan | <a href="mailto:nischaym@amazon.com">Contact Me</a></p>
+    <footer class="site-footer">
+        <div class="wrap">
+            <p>Tended by Nischay Mohan &middot; a learn-in-public digital garden.</p>
+        </div>
     </footer>
+
+    <script src="static/js/theme.js"></script>
 </body>
 </html>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,288 +1,409 @@
-/* Testing Banner */
-.test-banner {
-    background: #e60000;
-    color: #ffffff;
-    text-align: center;
-    padding: 10px;
-    font-weight: bold;
-    letter-spacing: 1px;
-    text-transform: uppercase;
+/* =========================================================================
+   Digital garden — design foundation
+   Typography-first, warm, minimal. Light + dark. Mobile-first.
+   ========================================================================= */
+
+/* ---- Design tokens -------------------------------------------------------
+   Colours are warm on purpose: paper-like light mode, lamp-lit dark mode.
+   Everything themable lives here so components stay theme-agnostic.        */
+:root {
+    /* Type: system fonts only — a readable serif for prose, a clean sans
+       for navigation / labels / UI. No web-font downloads. */
+    --font-serif: "Iowan Old Style", "Palatino Linotype", Palatino,
+        "Book Antiqua", Georgia, "Times New Roman", ui-serif, serif;
+    --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+        Helvetica, Arial, sans-serif;
+    --font-mono: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas,
+        monospace;
+
+    /* Reading measure + rhythm */
+    --measure: 40rem;          /* ~65–70 chars of prose            */
+    --measure-wide: 52rem;     /* diagrams / card grids            */
+    --line: 1.65;
+    --space: 1.5rem;
+
+    /* Light (warm paper) */
+    --bg: #f7f2ea;
+    --surface: #fffdf8;
+    --text: #2c2620;
+    --muted: #6d6455;
+    --faint: #8f8676;
+    --accent: #b0532f;         /* terracotta */
+    --accent-soft: #f0e2d6;
+    --border: #e4d9c8;
+    --shadow: rgba(64, 48, 32, 0.10);
+    --seedling: #5f7a3a;       /* leaf green */
+    --seedling-soft: #e7edda;
 }
 
-/* General Styling */
+:root[data-theme="dark"] {
+    --bg: #17140f;
+    --surface: #201b15;
+    --text: #ece3d5;
+    --muted: #ab9f8c;
+    --faint: #8a7f6d;
+    --accent: #e5926f;         /* warmer terracotta for contrast */
+    --accent-soft: #33261d;
+    --border: #342d24;
+    --shadow: rgba(0, 0, 0, 0.45);
+    --seedling: #a7c07a;
+    --seedling-soft: #26301a;
+}
+
+/* Respect system preference on very first paint if JS hasn't set a theme yet.
+   (A tiny inline <head> script normally sets data-theme to avoid any flash.) */
+@media (prefers-color-scheme: dark) {
+    :root:not([data-theme]) {
+        --bg: #17140f;
+        --surface: #201b15;
+        --text: #ece3d5;
+        --muted: #ab9f8c;
+        --faint: #8a7f6d;
+        --accent: #e5926f;
+        --accent-soft: #33261d;
+        --border: #342d24;
+        --shadow: rgba(0, 0, 0, 0.45);
+        --seedling: #a7c07a;
+        --seedling-soft: #26301a;
+    }
+}
+
+/* ---- Base ---------------------------------------------------------------- */
+*,
+*::before,
+*::after { box-sizing: border-box; }
+
+html { -webkit-text-size-adjust: 100%; }
+
 body {
-    font-family: 'Poppins', sans-serif;
     margin: 0;
-    padding: 0;
-    color: #ffffff;
-    background: linear-gradient(to right, #0f2027, #203a43, #2c5364);
+    background: var(--bg);
+    color: var(--text);
+    font-family: var(--font-serif);
+    font-size: 1.125rem;
+    line-height: var(--line);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+    transition: background-color 0.25s ease, color 0.25s ease;
 }
 
-/* Hero Section */
-.hero {
-    height: 500px;
+/* Comfortable, centred reading column with generous whitespace. */
+.wrap {
+    width: 100%;
+    max-width: var(--measure);
+    margin-inline: auto;
+    padding: 0 1.25rem;
+}
+.wrap--wide { max-width: var(--measure-wide); }
+
+main { padding: 2.5rem 0 4rem; }
+
+/* Headings use the sans face — a quiet contrast against serif prose. */
+h1, h2, h3, h4 {
+    font-family: var(--font-sans);
+    line-height: 1.2;
+    font-weight: 650;
+    letter-spacing: -0.01em;
+    margin: 2.25rem 0 0.75rem;
+}
+h1 { font-size: 2rem; margin-top: 0; }
+h2 { font-size: 1.4rem; }
+h3 { font-size: 1.15rem; }
+
+p { margin: 0 0 1.15rem; }
+
+a {
+    color: var(--accent);
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}
+a:hover { text-decoration-thickness: 2px; }
+
+hr {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0;
+}
+
+code {
+    font-family: var(--font-mono);
+    font-size: 0.9em;
+    background: var(--accent-soft);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+}
+
+::selection { background: var(--accent-soft); }
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+}
+.skip-link:focus {
+    left: 1rem;
+    top: 1rem;
+    background: var(--surface);
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    z-index: 10;
+}
+
+/* ---- Masthead + navigation ---------------------------------------------- */
+.site-header {
+    border-bottom: 1px solid var(--border);
+    background: color-mix(in srgb, var(--bg) 80%, transparent);
+    backdrop-filter: saturate(1.1) blur(6px);
+    position: sticky;
+    top: 0;
+    z-index: 5;
+}
+.site-header .wrap {
+    max-width: var(--measure-wide);
     display: flex;
     align-items: center;
-    justify-content: center;
-    text-align: center;
-    color: white;
-    background: url("/static/images/leshark.png") center/cover no-repeat;
-    animation: fadeIn 1.5s ease-in-out;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-block: 0.9rem;
 }
-
-.hero-content {
-    background: rgba(0, 0, 0, 0.7);
-    padding: 30px;
-    border-radius: 10px;
-    box-shadow: 0px 0px 20px rgba(255, 255, 255, 0.3);
-}
-
-/* Buttons */
-.btn {
-    display: inline-block;
-    padding: 12px 20px;
-    margin: 10px;
-    color: white;
-    background: #ff5733;
+.brand {
+    font-family: var(--font-sans);
+    font-weight: 700;
+    font-size: 1.05rem;
+    color: var(--text);
     text-decoration: none;
-    border-radius: 5px;
-    font-weight: bold;
-    transition: all 0.3s ease-in-out;
-    box-shadow: 0px 4px 10px rgba(255, 87, 51, 0.3);
+    letter-spacing: -0.01em;
+}
+.brand .leaf { color: var(--seedling); }
+
+.nav {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: var(--font-sans);
+    font-size: 0.95rem;
+}
+.nav a {
+    color: var(--muted);
+    text-decoration: none;
+    padding: 0.35rem 0.6rem;
+    border-radius: 6px;
+}
+.nav a:hover { color: var(--text); background: var(--accent-soft); }
+.nav a[aria-current="page"] { color: var(--text); font-weight: 600; }
+
+/* Theme toggle */
+.theme-toggle {
+    font-family: var(--font-sans);
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--muted);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    width: 2.1rem;
+    height: 2.1rem;
+    display: inline-grid;
+    place-items: center;
+    transition: color 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+}
+.theme-toggle:hover { color: var(--text); border-color: var(--accent); }
+.theme-toggle .icon-sun { display: none; }
+.theme-toggle .icon-moon { display: inline; }
+:root[data-theme="dark"] .theme-toggle .icon-sun { display: inline; }
+:root[data-theme="dark"] .theme-toggle .icon-moon { display: none; }
+
+/* ---- Hero / intro -------------------------------------------------------- */
+.intro { padding-top: 1rem; }
+.intro .kicker {
+    font-family: var(--font-sans);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    font-size: 0.72rem;
+    color: var(--faint);
+    margin-bottom: 0.5rem;
+}
+.intro h1 { font-size: clamp(2rem, 6vw, 2.8rem); }
+.intro .lede {
+    font-size: 1.25rem;
+    color: var(--muted);
 }
 
-.btn:hover {
-    background: #c70039;
-    transform: translateY(-3px);
-}
-
-.btn-alt {
-    background: #28a745;
-}
-
-.btn-alt:hover {
-    background: #218838;
-}
-
-/* Sections */
-section {
-    padding: 50px;
-    text-align: center;
-    background: rgba(255, 255, 255, 0.1);
-    margin: 20px;
-    border-radius: 10px;
-    box-shadow: 0px 0px 20px rgba(255, 255, 255, 0.2);
-}
-
-/* Skills */
-.skills-grid {
+/* Three-threads list */
+.threads {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    gap: 10px;
-    margin-top: 20px;
+    gap: 0.75rem;
+}
+.threads li {
+    padding-left: 1.5rem;
+    position: relative;
+}
+.threads li::before {
+    content: "→";
+    position: absolute;
+    left: 0;
+    color: var(--accent);
+    font-family: var(--font-sans);
 }
 
-.skill {
-    padding: 15px;
-    background: rgba(0, 123, 255, 0.8);
-    color: white;
-    border-radius: 5px;
-    font-weight: bold;
-    transition: transform 0.3s ease-in-out;
-}
-
-.skill:hover {
-    transform: scale(1.1);
-}
-
-/* Projects */
-.project-list {
+/* ---- Garden signals ------------------------------------------------------ */
+.meta {
+    font-family: var(--font-sans);
+    font-size: 0.8rem;
+    color: var(--faint);
     display: flex;
     flex-wrap: wrap;
-    justify-content: center;
-    gap: 20px;
+    gap: 0.35rem 1rem;
+    margin: 0.25rem 0 0;
 }
+.meta time { color: var(--muted); }
 
-.project {
-    width: 300px;
-    padding: 20px;
-    background: rgba(255, 255, 255, 0.2);
+.badge {
+    font-family: var(--font-sans);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    padding: 0.15rem 0.55rem;
+    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    border: 1px solid transparent;
+    vertical-align: middle;
+}
+.badge--seedling { color: var(--seedling); background: var(--seedling-soft); }
+.badge--stub { color: var(--muted); background: var(--accent-soft); }
+.badge--evergreen { color: var(--accent); background: var(--accent-soft); }
+
+/* "Related" backlinks block */
+.backlinks {
+    margin-top: 2.5rem;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--seedling);
+    border-radius: 8px;
+    padding: 1rem 1.25rem;
+    background: var(--surface);
+}
+.backlinks h2 {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--faint);
+    margin: 0 0 0.6rem;
+}
+.backlinks ul { margin: 0; padding-left: 1.1rem; }
+.backlinks li { margin: 0.3rem 0; }
+
+/* ---- Cards (atomic notes) ------------------------------------------------ */
+.card-grid {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: 1fr;
+}
+.card {
+    border: 1px solid var(--border);
+    background: var(--surface);
     border-radius: 10px;
-    box-shadow: 0px 0px 20px rgba(255, 255, 255, 0.2);
-    transition: transform 0.3s ease-in-out;
+    padding: 1.1rem 1.25rem;
+    transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
-
-.project:hover {
-    transform: translateY(-5px);
+.card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px var(--shadow);
+    border-color: var(--accent);
 }
+.card h3 { margin: 0 0 0.35rem; }
+.card h3 a { color: var(--text); text-decoration: none; }
+.card h3 a:hover { color: var(--accent); }
+.card p { color: var(--muted); font-size: 0.98rem; margin: 0.5rem 0 0.75rem; }
 
-.project img {
-    width: 100%;
-    border-radius: 5px;
+/* ---- Essay body ---------------------------------------------------------- */
+.essay { }
+.essay h1 { margin-bottom: 0.4rem; }
+.essay > p:first-of-type { font-size: 1.18rem; }
+.essay blockquote {
+    margin: 1.5rem 0;
+    padding-left: 1.1rem;
+    border-left: 3px solid var(--accent);
+    color: var(--muted);
+    font-style: italic;
 }
+.essay ul, .essay ol { padding-left: 1.4rem; }
+.essay li { margin: 0.35rem 0; }
 
-/* Footer */
-footer {
+/* ---- Hand-drawn flow diagrams (a signature element) ---------------------- */
+/* Diagrams are inline SVG drawn with currentColor, so they invert cleanly
+   between themes. A subtle displacement filter gives the hand-drawn wobble. */
+.diagram {
+    margin: 2rem 0;
+    color: var(--text);
+}
+.diagram figcaption,
+.diagram .caption {
+    font-family: var(--font-sans);
+    font-size: 0.82rem;
+    color: var(--faint);
     text-align: center;
-    padding: 20px;
-    background: rgba(0, 0, 0, 0.8);
-    color: white;
+    margin-top: 0.6rem;
+}
+.diagram svg {
+    width: 100%;
+    height: auto;
+    display: block;
+    overflow: visible;
+}
+.diagram .node {
+    fill: var(--surface);
+    stroke: currentColor;
+    stroke-width: 2;
+}
+.diagram .flow {
+    stroke: var(--accent);
+    stroke-width: 2;
+    fill: none;
+}
+.diagram .label {
+    font-family: var(--font-sans);
+    font-size: 15px;
+    fill: var(--text);
+    stroke: none;
+}
+.diagram .sub {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    fill: var(--muted);
+    stroke: none;
+}
+.diagram .flow-label {
+    font-family: var(--font-sans);
+    font-size: 12px;
+    fill: var(--accent);
+    stroke: none;
 }
 
-/* Animations */
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-        transform: translateY(20px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
+/* ---- Footer -------------------------------------------------------------- */
+.site-footer {
+    border-top: 1px solid var(--border);
+    padding: 2rem 0 3rem;
+    color: var(--faint);
+    font-family: var(--font-sans);
+    font-size: 0.85rem;
+}
+.site-footer a { color: var(--muted); }
+
+/* ---- Responsive: the layout is mobile-first; widen on larger screens ---- */
+@media (min-width: 40rem) {
+    body { font-size: 1.15rem; }
+    .card-grid { grid-template-columns: 1fr 1fr; }
 }
 
-.fade-in {
-    animation: fadeIn 1.5s ease-in-out;
-}
-
-.fade-in-delay {
-    animation: fadeIn 2s ease-in-out;
-}
-
-.fade-in-late {
-    animation: fadeIn 2.5s ease-in-out;
-}
-
-/* Navigation Bar */
-nav {
-    display: flex;
-    justify-content: center;
-    background: rgba(0, 0, 0, 0.8);
-    padding: 15px;
-    border-bottom: 3px solid #ff5733;
-}
-
-nav a {
-    color: white;
-    text-decoration: none;
-    font-size: 1.2rem;
-    font-weight: bold;
-    margin: 0 20px;
-    padding: 10px 15px;
-    border-radius: 5px;
-    transition: all 0.3s ease-in-out;
-}
-
-nav a:hover {
-    background: #ff5733;
-    transform: scale(1.1);
-}
-
-#chat-container {
-    width: 300px;
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: white;
-    border: 2px solid #333;
-    border-radius: 10px;
-    padding: 10px;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
-}
-
-#chat-box {
-    height: 200px;
-    overflow-y: scroll;
-    padding: 5px;
-}
-
-#user-input {
-    width: 80%;
-    padding: 5px;
-}
-
-#send-btn {
-    width: 15%;
-    padding: 5px;
-    background: #ff5733;
-    color: white;
-    border: none;
-    cursor: pointer;
-}
-
-/* Floating Chatbot Icon */
-#chat-icon {
-    position: fixed;
-    bottom: 20px;
-    right: 20px;
-    background: #ff5733;
-    color: white;
-    font-size: 24px;
-    padding: 15px;
-    border-radius: 50%;
-    cursor: pointer;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.2);
-    transition: transform 0.3s ease-in-out;
-}
-
-#chat-icon:hover {
-    transform: scale(1.1);
-}
-
-/* Chatbot Container */
-#chat-container {
-    position: fixed;
-    bottom: 80px;
-    right: 20px;
-    width: 300px;
-    background: white;
-    border-radius: 10px;
-    padding: 10px;
-    box-shadow: 0px 4px 10px rgba(0, 0, 0, 0.3);
-    display: none;
-    flex-direction: column;
-}
-
-/* Show chat when active */
-#chat-container.active {
-    display: flex;
-}
-
-/* Chat Header */
-#chat-header {
-    background: #ff5733;
-    color: white;
-    padding: 10px;
-    font-weight: bold;
-    display: flex;
-    justify-content: space-between;
-    border-top-left-radius: 8px;
-    border-top-right-radius: 8px;
-}
-
-/* Chat Messages */
-#chat-box {
-    height: 250px;
-    overflow-y: auto;
-    padding: 5px;
-    font-size: 14px;
-    background: #f4f4f4;
-}
-
-/* User Input and Send Button */
-#user-input {
-    width: 75%;
-    padding: 8px;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-}
-
-#send-btn {
-    width: 20%;
-    padding: 8px;
-    background: #ff5733;
-    color: white;
-    border: none;
-    cursor: pointer;
-    border-radius: 5px;
+@media (prefers-reduced-motion: reduce) {
+    * { transition: none !important; scroll-behavior: auto !important; }
 }

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,0 +1,54 @@
+// Theme toggle: respects the OS preference by default, lets the reader
+// override it, and remembers the choice. The initial theme is set by a tiny
+// inline <head> script (see pages) so there's no flash of the wrong theme.
+(function () {
+  var root = document.documentElement;
+  var mql = window.matchMedia("(prefers-color-scheme: dark)");
+
+  function stored() {
+    try { return localStorage.getItem("theme"); } catch (e) { return null; }
+  }
+  function save(value) {
+    try { localStorage.setItem("theme", value); } catch (e) {}
+  }
+  function current() {
+    return root.getAttribute("data-theme") ||
+      (mql.matches ? "dark" : "light");
+  }
+  function apply(theme, buttons) {
+    root.setAttribute("data-theme", theme);
+    buttons.forEach(function (btn) {
+      btn.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+      btn.setAttribute(
+        "aria-label",
+        theme === "dark" ? "Switch to light theme" : "Switch to dark theme"
+      );
+    });
+  }
+
+  function init() {
+    var buttons = Array.prototype.slice.call(
+      document.querySelectorAll("[data-theme-toggle]")
+    );
+    apply(current(), buttons);
+
+    buttons.forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var next = current() === "dark" ? "light" : "dark";
+        save(next);
+        apply(next, buttons);
+      });
+    });
+
+    // Follow the OS if the reader hasn't made an explicit choice.
+    mql.addEventListener("change", function (e) {
+      if (!stored()) apply(e.matches ? "dark" : "light", buttons);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Establishes the overall design & feel for the site as a **digital garden** (Prompt 1). No content is finalized — copy is on-theme placeholder to demonstrate the system; later prompts refine each section.

- **Typography-first, warm, minimal:** system fonts only (readable serif for prose, clean sans for nav/labels), comfortable reading measure, generous whitespace, warm light + dark palettes.
- **Light/dark toggle** (`static/js/theme.js`): respects `prefers-color-scheme`, lets the reader override, persists in `localStorage`, and an inline `<head>` script prevents any flash of the wrong theme.
- **Digital-garden signals:** "Created" / "Last tended" dates, `Seedling` / `Stub` / `Evergreen` badges, and a lightweight "Related" backlinks block.
- **Hand-drawn-feeling flow diagrams as a signature element:** inline SVG painted with `currentColor` (so it reads in both themes) with a subtle `feDisplacementMap` wobble — no web-font/JS dependency. Example: a card payment authorize→settle flow.
- **Mobile-first** throughout; honors `prefers-reduced-motion`.
- Removed the temporary red "Testing" banner and dropped the résumé-era / employer-specific homepage content and the client-side chatbot include (kept everything employer-agnostic per the master framing).

## Pages
`index.html` (garden home + signature diagram), `how-money-moves.html` (example seedling essay with inline diagram + backlinks), `about.html` (colophon), `projects.html` (Notes index).

## Walkthrough
[garden_design_light_dark_demo.mp4](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgarden_design_light_dark_demo.mp4)

[Home flow diagram, light](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgarden_home_light.webp)
[Flow diagram, dark](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgarden_diagram_dark.webp)
[Seedling essay with inline diagram](https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgarden_essay.webp)

Verified in Chrome in light & dark: theme toggle works with no flash, both hand-drawn diagrams stay legible in each theme, garden signals and backlinks render, and layout holds up.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69c4d2e2-4417-4839-8cb0-ac3f5f611366"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

